### PR TITLE
Replaced onCreate with onStart calls.

### DIFF
--- a/HackVG/app/src/main/java/com/hackvg/android/mvp/presenters/MovieDetailPresenter.java
+++ b/HackVG/app/src/main/java/com/hackvg/android/mvp/presenters/MovieDetailPresenter.java
@@ -12,7 +12,7 @@ public interface MovieDetailPresenter  {
 
     public void onResume();
 
-    public void onCreate ();
+    public void onStart ();
 
     public void onStop ();
 

--- a/HackVG/app/src/main/java/com/hackvg/android/mvp/presenters/MovieDetailPresenterImpl.java
+++ b/HackVG/app/src/main/java/com/hackvg/android/mvp/presenters/MovieDetailPresenterImpl.java
@@ -50,7 +50,7 @@ public class MovieDetailPresenterImpl implements MovieDetailPresenter {
     }
 
     @Override
-    public void onCreate() {
+    public void onStart() {
 
         BusProvider.getUIBusInstance().register(this);
     }

--- a/HackVG/app/src/main/java/com/hackvg/android/mvp/presenters/PopularShowsPresenter.java
+++ b/HackVG/app/src/main/java/com/hackvg/android/mvp/presenters/PopularShowsPresenter.java
@@ -7,7 +7,7 @@ import com.hackvg.model.entities.PopularMoviesApiResponse;
  */
 public interface PopularShowsPresenter {
 
-    public void onCreate ();
+    public void onStart ();
 
     public void onStop ();
 

--- a/HackVG/app/src/main/java/com/hackvg/android/mvp/presenters/PopularShowsPresenterImpl.java
+++ b/HackVG/app/src/main/java/com/hackvg/android/mvp/presenters/PopularShowsPresenterImpl.java
@@ -19,7 +19,7 @@ public class PopularShowsPresenterImpl implements PopularShowsPresenter {
     }
 
     @Override
-    public void onCreate() {
+    public void onStart() {
 
         BusProvider.getUIBusInstance().register(this);
 

--- a/HackVG/app/src/main/java/com/hackvg/android/views/activities/MVPDetailActivity.java
+++ b/HackVG/app/src/main/java/com/hackvg/android/views/activities/MVPDetailActivity.java
@@ -58,7 +58,12 @@ public class MVPDetailActivity extends Activity
         fabPending.setOnClickListener(this);
 
         this.detailPresenter = new MovieDetailPresenterImpl(this, movieID);
-        this.detailPresenter.onCreate();
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        this.detailPresenter.onStart();
     }
 
     @Override

--- a/HackVG/app/src/main/java/com/hackvg/android/views/activities/MoviesActivity.java
+++ b/HackVG/app/src/main/java/com/hackvg/android/views/activities/MoviesActivity.java
@@ -74,7 +74,12 @@ public class MoviesActivity extends ActionBarActivity implements
             (DrawerLayout) findViewById(R.id.drawer_layout));
 
         popularShowsPresenter = new PopularShowsPresenterImpl(this);
-        popularShowsPresenter.onCreate();
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        popularShowsPresenter.onStart();
     }
 
     @Override


### PR DESCRIPTION
Replaced the onCreate calls with onStart calls, this should solve the problem with the multiple unregister calls.
As shown in this [issue](https://github.com/saulmm/Material-Movies/issues/1#issuecomment-73361087)
